### PR TITLE
Replace the heavy jQuery.timeago plugin with a smaller library.

### DIFF
--- a/lib/templates/list.js
+++ b/lib/templates/list.js
@@ -1,6 +1,6 @@
 var path = require('path'),
     chalk = require('chalk'),
-    timeago = require('timeago'),
+    timeago = new require('timeago.js')(),
     homePath = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'],
     uRepeat = require('../str-repeat');
 
@@ -30,7 +30,7 @@ module.exports = function(opts) {
   songs.forEach(function(song) {
     dirnames.push(chalk.gray.dim(path.dirname(song.path).replace(homePath, '~') + path.sep));
     filenames.push(path.basename(song.path, path.extname(song.path)));
-    lastPlayed.push((song.lastPlay !== 0 ? ' > ' + timeago(song.lastPlay) : ''));
+    lastPlayed.push((song.lastPlay !== 0 ? ' > ' + timeago.format(song.lastPlay) : ''));
     playCounts.push(song.playCount || 0);
     ratings.push(song.rating || 0);
   });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "chalk": "^0.5.1",
     "keypress": "0.1.0",
     "pipe-iterators": "^1.1.0",
-    "timeago": "~0.2.0",
+    "timeago.js": "~2.0.3",
     "xtend": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
`nplay` is a nice project. I replace the heavy jQuery.timeago plugin with a smaller library named [timeago.js](https://github.com/hustcc/timeago.js).

This library is ~2KB, has no dependencies and includes several built-in locales. It also updates the timestamp on the page in realtime.